### PR TITLE
Fix : Multiple Fixes based on the word doc what we got from client.

### DIFF
--- a/src/constants/FooterData.ts
+++ b/src/constants/FooterData.ts
@@ -23,7 +23,7 @@ export const footerData: FooterData = {
   },
   socials: [
     { icon: "FaInstagram", href: "https://instagram.com/label_rune" },
-    { icon: "FaFacebook", href: "#" },
-    { icon: "FaTwitter", href: "#" },
+    // { icon: "FaFacebook", href: "#" },
+    // { icon: "FaTwitter", href: "#" },
   ],
 };

--- a/src/constants/NavbarData.ts
+++ b/src/constants/NavbarData.ts
@@ -10,7 +10,7 @@ export const NavItems: NavbarType[] = [
   },
   {
     id: "2",
-    label: "Shop",
+    label: "Discover Styles",
     href: "#",
     hasDropdown: true,
     dropdownItems: [

--- a/src/molecules/common/ProductAccordian.tsx
+++ b/src/molecules/common/ProductAccordian.tsx
@@ -41,7 +41,11 @@ const accordionData: AccordionItem[] = [
     title: "Color & Craft Notice",
     content: (
       <div className="space-y-1 text-gray-700">
-        <p>Colors may vary slightly due to screen settings. Minor irregularities in embroidery, color, or print are natural and part of the product's handcrafted charm.</p>
+        <p>
+          Colors may vary slightly due to screen settings. Minor irregularities
+          in embroidery, color, or print are natural and part of the product's
+          handcrafted charm.
+        </p>
       </div>
     ),
     icon: <CgColorBucket className="text-xl" />,
@@ -51,13 +55,29 @@ const accordionData: AccordionItem[] = [
     title: "Exchanges & Returns",
     content: (
       <ul className="space-y-1 text-gray-700">
-        <li>• Minor irregularities in colour, texture, or weave are natural and not defects.</li>
-        <li>• No returns; size exchanges accepted on unworn, unwashed items.</li>
-        <li>• Returns are eligible for store credit only; refunds apply only to unfulfilled orders.</li>
+        <li>
+          • Minor irregularities in colour, texture, or weave are natural and
+          not defects.
+        </li>
+        <li>
+          • No returns; size exchanges accepted on unworn, unwashed items.
+        </li>
+        <li>
+          • Returns are eligible for store credit only; refunds apply only to
+          unfulfilled orders.
+        </li>
         <li>• Report damaged items within 48 hours with proof.</li>
-        <li>• Email reachus@labelrune.com with your order number for exchanges. Response within 5 working days.</li>
-        <li>• No exchanges or returns on custom-made, international, or sale items.</li>
-        <li>• Ship exchanges with a note including your name and return address.</li>
+        <li>
+          • Email reachus@labelrune.com with your order number for exchanges.
+          Response within 5 working days.
+        </li>
+        <li>
+          • No exchanges or returns on custom-made, international, or sale
+          items.
+        </li>
+        <li>
+          • Ship exchanges with a note including your name and return address.
+        </li>
       </ul>
     ),
     icon: <GiReturnArrow className="text-xl" />,
@@ -84,16 +104,18 @@ export default function ProductAccordion() {
               <span className="font-semibold">{item.title}</span>
             </div>
             <IoChevronDownSharp
-              className={`text-lg transition-transform duration-300 ${openId === item.id ? "rotate-180" : ""
-                }`}
+              className={`text-lg transition-transform duration-300 ${
+                openId === item.id ? "rotate-180" : ""
+              }`}
             />
           </button>
 
           <div
-            className={`overflow-hidden transition-all duration-300 ${openId === item.id
-              ? "max-h-96 opacity-100 p-2 md:p-4"
-              : "max-h-0 opacity-0"
-              }`}
+            className={`overflow-hidden transition-all duration-300 ${
+              openId === item.id
+                ? "max-h-96 opacity-100 md:p-4"
+                : "max-h-0 opacity-0"
+            }`}
           >
             {openId === item.id && item.content}
           </div>

--- a/src/molecules/product/ProductInfo.tsx
+++ b/src/molecules/product/ProductInfo.tsx
@@ -5,9 +5,10 @@ import { FBProduct, SizeChart } from "src/types/common";
 import { formatPrice } from "src/utils/common";
 import ProductAccordion from "../common/ProductAccordian";
 import { Carousel } from "react-responsive-carousel";
-import 'react-responsive-carousel/lib/styles/carousel.min.css';
+import "react-responsive-carousel/lib/styles/carousel.min.css";
 import { FiChevronLeft, FiChevronRight } from "react-icons/fi";
 import { createPortal } from "react-dom";
+import Link from "next/link";
 
 const MaxQuantity = 9;
 
@@ -52,123 +53,200 @@ export default function ProductInfo({
   };
   return (
     <>
-      {
-        showChart ? createPortal(
-          <div
-            className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center"
-            onClick={() => setShowChart(false)}
-          >
+      {showChart
+        ? createPortal(
             <div
-              className="bg-white p-6 rounded shadow-lg max-w-full w-[95vw] md:w-[900px] max-h-[90vh] overflow-y-auto relative"
-              onClick={e => e.stopPropagation()}
+              className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center"
+              onClick={() => setShowChart(false)}
             >
-              <div className="absolute top-4 left-4 flex items-center gap-2">
-                <span className="text-xs font-semibold mr-1">in</span>
-                <button
-                  type="button"
-                  className={`cursor-pointer w-12 h-6 flex items-center rounded-full transition-colors duration-300 focus:outline-none ${showCm ? "bg-gray-300" : "bg-black/80"}`}
-                  onClick={() => setShowCm((prev) => !prev)}
-                  aria-label="Toggle cm/in"
-                >
-                  <span
-                    className={`w-5 h-5 bg-white rounded-full shadow transform transition-transform duration-300 ${showCm ? "translate-x-6" : "translate-x-1"}`}
-                  />
-                </button>
-                <span className="text-xs font-semibold ml-1">cm</span>
-              </div>
-              <button
-                className="cursor-pointer absolute top-4 right-4 text-2xl font-bold text-gray-500 hover:text-black"
-                onClick={() => setShowChart(false)}
-                aria-label="Close"
+              <div
+                className="bg-white p-6 rounded shadow-lg max-w-full w-[95vw] md:w-[900px] max-h-[90vh] overflow-y-auto relative"
+                onClick={(e) => e.stopPropagation()}
               >
-                ×
-              </button>
-              <div className="mt-12">
-                <div className="text-xl font-bold mb-2">
-                  SIZE CHART &#123;Top/Kurti/Tunic/Dresses&#125;
+                <div className="absolute top-4 left-4 flex items-center gap-2">
+                  <span className="text-xs font-semibold mr-1">in</span>
+                  <button
+                    type="button"
+                    className={`cursor-pointer w-12 h-6 flex items-center rounded-full transition-colors duration-300 focus:outline-none ${
+                      showCm ? "bg-gray-300" : "bg-black/80"
+                    }`}
+                    onClick={() => setShowCm((prev) => !prev)}
+                    aria-label="Toggle cm/in"
+                  >
+                    <span
+                      className={`w-5 h-5 bg-white rounded-full shadow transform transition-transform duration-300 ${
+                        showCm ? "translate-x-6" : "translate-x-1"
+                      }`}
+                    />
+                  </button>
+                  <span className="text-xs font-semibold ml-1">cm</span>
                 </div>
-                <div className="mb-4 text-sm text-gray-600">
-                  Below Measurement is Body Measurement Size ({showCm ? "cm" : "in"})
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="min-w-full border border-gray-300 text-center text-sm">
-                    <thead>
-                      <tr className="bg-gray-100">
-                        <th className="border px-2 py-1"> </th>
-                        <th className="border px-2 py-1">XS</th>
-                        <th className="border px-2 py-1">S</th>
-                        <th className="border px-2 py-1">M</th>
-                        <th className="border px-2 py-1">L</th>
-                        <th className="border px-2 py-1">XL</th>
-                        <th className="border px-2 py-1">XXL</th>
-                        <th className="border px-2 py-1">3XL</th>
-                        <th className="border px-2 py-1">4XL</th>
-                        <th className="border px-2 py-1">5XL</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {[
-                        { label: "Bust", in: [32, 34, 36, 38, 40, 42, 44, 46, 48], cm: [81.3, 86.4, 91.4, 96.5, 101.6, 106.7, 111.8, 116.8, 121.9] },
-                        { label: "Waist", in: [25, 27, 29, 31, 33, 35, 37, 39, 41], cm: [63.5, 68.6, 73.7, 78.7, 83.8, 88.9, 94.0, 99.1, 104.1] },
-                        { label: "Hip", in: [36, 38, 40, 42, 44, 46, 48, 50, 52], cm: [91.4, 96.5, 101.6, 106.7, 111.8, 116.8, 121.9, 127.0, 132.1] },
-                        { label: "Shoulder", in: [13.5, 14, 14.5, 15, 15.5, 16, 16.5, 17, 17.5], cm: [34.3, 35.6, 36.8, 38.1, 39.4, 40.6, 41.9, 43.2, 44.5] },
-                        { label: "Length", in: [26, 26, 26, 26, 26, 26, 26, 26, 26], cm: [66.0, 66.0, 66.0, 66.0, 66.0, 66.0, 66.0, 66.0, 66.0] },
-                        { label: "Armhole", in: [17.5, 18, 18.5, 19, 19.5, 20, 20.5, 21, 21.5], cm: [44.5, 45.7, 47.0, 48.3, 49.5, 50.8, 52.1, 53.3, 54.6] },
-                      ].map(row => (
-                        <tr key={row.label}>
-                          <td className="border px-2 py-1 font-semibold">{row.label}</td>
-                          {(showCm ? row.cm : row.in).map((val, i) => (
-                            <td className="border px-2 py-1" key={i}>{val}</td>
-                          ))}
+                <button
+                  className="cursor-pointer absolute top-4 right-4 text-2xl font-bold text-gray-500 hover:text-black"
+                  onClick={() => setShowChart(false)}
+                  aria-label="Close"
+                >
+                  ×
+                </button>
+                <div className="mt-12">
+                  <div className="text-xl font-bold mb-2">
+                    SIZE CHART &#123;Top/Kurti/Tunic/Dresses&#125;
+                  </div>
+                  <div className="mb-4 text-sm text-gray-600">
+                    Below Measurement is Body Measurement Size (
+                    {showCm ? "cm" : "in"})
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full border border-gray-300 text-center text-sm">
+                      <thead>
+                        <tr className="bg-gray-100">
+                          <th className="border px-2 py-1"> </th>
+                          <th className="border px-2 py-1">XS</th>
+                          <th className="border px-2 py-1">S</th>
+                          <th className="border px-2 py-1">M</th>
+                          <th className="border px-2 py-1">L</th>
+                          <th className="border px-2 py-1">XL</th>
+                          <th className="border px-2 py-1">XXL</th>
+                          <th className="border px-2 py-1">3XL</th>
+                          <th className="border px-2 py-1">4XL</th>
+                          <th className="border px-2 py-1">5XL</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-                <div className="text-xl font-bold mt-8 mb-2">
-                  SIZE CHART &#123;Pants/Shorts&#125;
-                </div>
-                <div className="mb-4 text-sm text-gray-600">
-                  Below Measurement is Body Measurement Size ({showCm ? "cm" : "in"})
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="min-w-full border border-gray-300 text-center text-sm">
-                    <thead>
-                      <tr className="bg-gray-100">
-                        <th className="border px-2 py-1"> </th>
-                        <th className="border px-2 py-1">XS</th>
-                        <th className="border px-2 py-1">S</th>
-                        <th className="border px-2 py-1">M</th>
-                        <th className="border px-2 py-1">L</th>
-                        <th className="border px-2 py-1">XL</th>
-                        <th className="border px-2 py-1">XXL</th>
-                        <th className="border px-2 py-1">3XL</th>
-                        <th className="border px-2 py-1">4XL</th>
-                        <th className="border px-2 py-1">5XL</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {[
-                        { label: "Length", in: [37, 37, 37, 37, 37, 37, 37, 37, 37], cm: [94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0] },
-                        { label: "Waist", in: [25, 27, 29, 31, 33, 35, 37, 39, 41], cm: [63.5, 68.6, 73.7, 78.7, 83.8, 88.9, 94.0, 99.1, 104.1] },
-                        { label: "Hip", in: [36, 38, 40, 42, 44, 46, 48, 50, 52], cm: [91.4, 96.5, 101.6, 106.7, 111.8, 116.8, 121.9, 127.0, 132.1] },
-                      ].map(row => (
-                        <tr key={row.label}>
-                          <td className="border px-2 py-1 font-semibold">{row.label}</td>
-                          {(showCm ? row.cm : row.in).map((val, i) => (
-                            <td className="border px-2 py-1" key={i}>{val}</td>
-                          ))}
+                      </thead>
+                      <tbody>
+                        {[
+                          {
+                            label: "Bust",
+                            in: [32, 34, 36, 38, 40, 42, 44, 46, 48],
+                            cm: [
+                              81.3, 86.4, 91.4, 96.5, 101.6, 106.7, 111.8,
+                              116.8, 121.9,
+                            ],
+                          },
+                          {
+                            label: "Waist",
+                            in: [25, 27, 29, 31, 33, 35, 37, 39, 41],
+                            cm: [
+                              63.5, 68.6, 73.7, 78.7, 83.8, 88.9, 94.0, 99.1,
+                              104.1,
+                            ],
+                          },
+                          {
+                            label: "Hip",
+                            in: [36, 38, 40, 42, 44, 46, 48, 50, 52],
+                            cm: [
+                              91.4, 96.5, 101.6, 106.7, 111.8, 116.8, 121.9,
+                              127.0, 132.1,
+                            ],
+                          },
+                          {
+                            label: "Shoulder",
+                            in: [13.5, 14, 14.5, 15, 15.5, 16, 16.5, 17, 17.5],
+                            cm: [
+                              34.3, 35.6, 36.8, 38.1, 39.4, 40.6, 41.9, 43.2,
+                              44.5,
+                            ],
+                          },
+                          {
+                            label: "Length",
+                            in: [26, 26, 26, 26, 26, 26, 26, 26, 26],
+                            cm: [
+                              66.0, 66.0, 66.0, 66.0, 66.0, 66.0, 66.0, 66.0,
+                              66.0,
+                            ],
+                          },
+                          {
+                            label: "Armhole",
+                            in: [17.5, 18, 18.5, 19, 19.5, 20, 20.5, 21, 21.5],
+                            cm: [
+                              44.5, 45.7, 47.0, 48.3, 49.5, 50.8, 52.1, 53.3,
+                              54.6,
+                            ],
+                          },
+                        ].map((row) => (
+                          <tr key={row.label}>
+                            <td className="border px-2 py-1 font-semibold">
+                              {row.label}
+                            </td>
+                            {(showCm ? row.cm : row.in).map((val, i) => (
+                              <td className="border px-2 py-1" key={i}>
+                                {val}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                  <div className="text-xl font-bold mt-8 mb-2">
+                    SIZE CHART &#123;Pants/Shorts&#125;
+                  </div>
+                  <div className="mb-4 text-sm text-gray-600">
+                    Below Measurement is Body Measurement Size (
+                    {showCm ? "cm" : "in"})
+                  </div>
+                  <div className="overflow-x-auto">
+                    <table className="min-w-full border border-gray-300 text-center text-sm">
+                      <thead>
+                        <tr className="bg-gray-100">
+                          <th className="border px-2 py-1"> </th>
+                          <th className="border px-2 py-1">XS</th>
+                          <th className="border px-2 py-1">S</th>
+                          <th className="border px-2 py-1">M</th>
+                          <th className="border px-2 py-1">L</th>
+                          <th className="border px-2 py-1">XL</th>
+                          <th className="border px-2 py-1">XXL</th>
+                          <th className="border px-2 py-1">3XL</th>
+                          <th className="border px-2 py-1">4XL</th>
+                          <th className="border px-2 py-1">5XL</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {[
+                          {
+                            label: "Length",
+                            in: [37, 37, 37, 37, 37, 37, 37, 37, 37],
+                            cm: [
+                              94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0, 94.0,
+                              94.0,
+                            ],
+                          },
+                          {
+                            label: "Waist",
+                            in: [25, 27, 29, 31, 33, 35, 37, 39, 41],
+                            cm: [
+                              63.5, 68.6, 73.7, 78.7, 83.8, 88.9, 94.0, 99.1,
+                              104.1,
+                            ],
+                          },
+                          {
+                            label: "Hip",
+                            in: [36, 38, 40, 42, 44, 46, 48, 50, 52],
+                            cm: [
+                              91.4, 96.5, 101.6, 106.7, 111.8, 116.8, 121.9,
+                              127.0, 132.1,
+                            ],
+                          },
+                        ].map((row) => (
+                          <tr key={row.label}>
+                            <td className="border px-2 py-1 font-semibold">
+                              {row.label}
+                            </td>
+                            {(showCm ? row.cm : row.in).map((val, i) => (
+                              <td className="border px-2 py-1" key={i}>
+                                {val}
+                              </td>
+                            ))}
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>,
-          document.body
-        ) : null
-      }
+            </div>,
+            document.body
+          )
+        : null}
       <div className="w-full flex flex-col md:flex-row gap-5 md:gap-16 items-start">
         <div className="max-md:flex-1 md:w-full flex flex-col">
           <Carousel
@@ -205,15 +283,13 @@ export default function ProductInfo({
               )
             }
           >
-            {
-              imageLinks.map(link => (
-                <img
-                  key={link}
-                  src={link}
-                  className="aspect-[2/3] bg-red-300 h-full"
-                />
-              ))
-            }
+            {imageLinks.map((link) => (
+              <img
+                key={link}
+                src={link}
+                className="aspect-[2/3] bg-red-300 h-full"
+              />
+            ))}
           </Carousel>
           <div className="mt-2 flex flex-row gap-1.5">
             {imageLinks.map((imageLink, idx) => {
@@ -249,8 +325,13 @@ export default function ProductInfo({
           {Object.keys(sizeOptions).length ? (
             <div className="flex flex-row justify-between items-center w-full mt-4">
               {/* <div>Size</div> */}
-              <div className="">*No hidden charges. Select your size at checkout.</div>
-              <div onClick={() => setShowChart(true)} className="font-semibold underline cursor-pointer">
+              <div className="">
+                *No hidden charges. Select your size at checkout.
+              </div>
+              <div
+                onClick={() => setShowChart(true)}
+                className="font-semibold underline cursor-pointer"
+              >
                 Size Chart
               </div>
             </div>
@@ -295,7 +376,10 @@ export default function ProductInfo({
           {/* <div className="flex justify-center items-center border-black border-2 py-4 cursor-pointer text-xl hover:border-4 hover:mt-3 hover:translate-y-0.5 mt-4">
             Add to Cart
           </div> */}
-          <div onClick={() => handleBuyNow(selectedSize.paymentLink)} className="flex transition-all rounded-md justify-center items-center text-[#FDF7ED] hover:opacity-90 bg-[#293035] py-4 cursor-pointer text-xl mt-8">
+          <div
+            onClick={() => handleBuyNow(selectedSize.paymentLink)}
+            className="flex transition-all rounded-md justify-center items-center text-[#FDF7ED] hover:opacity-90 bg-[#293035] py-4 cursor-pointer text-xl mt-8"
+          >
             BUY NOW
           </div>
           <div className="mt-8 text-lg">{description}</div>
@@ -320,7 +404,10 @@ export default function ProductInfo({
             const randomIndex =
               Math.round(Math.random() * imagesCount + 1.01) % imagesCount;
             return (
-              <div
+              <Link
+                href={`/product/${product.id}-${productName
+                  .replace(/\s+/g, "-")
+                  .toLowerCase()}`}
                 className="snap-center flex flex-col gap-2 md:gap-3 group w-[calc(100%/2-12px)] md:w-[calc(100%/4-12px)]"
                 key={index}
               >
@@ -351,7 +438,7 @@ export default function ProductInfo({
                     )}`}</span>
                   </div>
                 )}
-              </div>
+              </Link>
             );
           })}
         </div>


### PR DESCRIPTION
### Here is the list of the fixes, point wise based on word doc what we get.

1. Name of `shop-all` is now changed to `discover styles` on the navbar.
3. Facebook and twitter symbols has been removed as we don't have any reference link of `rune` on these two platform.
4. Yes, Nyah product has a strike off price same as net price, it is just for the feel of how this strike-off price will look on the UI. But the price is being taken from the price sheet itself shared by client.
5. UI line issue on mobile has being addressed and now works correctly.
6. Not in our scope as of now, as includes payment gateways flow.
7. Fixed: When viewing a product at the end of the page “You may also Like” displays but not products are clickable.
8. Not in current scope.
9. Will look into it later.
10. Again cashfree stuffs.